### PR TITLE
Fix upload-artifact for macos

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -37,7 +37,7 @@ jobs: # credits for workflow from https://github.com/messense/crfs-rs/blob/main/
         uses: actions/upload-artifact@v3
         with:
           name: wheels-macos
-          paths: |
+          path: |
             dist-x86-64
             dist-universal2
 


### PR DESCRIPTION
The `path:` argument can take a list, but there's no `paths:`.