### PR TITLE
Remove tag requirement from release workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -209,7 +209,6 @@ jobs: # credits for workflow from https://github.com/messense/crfs-rs/blob/main/
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
     needs: [ macos, windows, linux, linux-cross, musllinux, musllinux-cross ]
     steps:
       - uses: actions/download-artifact@v3 # download all artifacts


### PR DESCRIPTION
We already only run on `tags: ['*']`, but if we manually trigger this run it will never push the images.