### PR TITLE
Fix macos upload

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -237,4 +237,4 @@ jobs: # credits for workflow from https://github.com/messense/crfs-rs/blob/main/
           twine upload --skip-existing *
           popd
           pushd wheels-macos
-          twine upload --skip-existing *
+          twine upload --skip-existing **/*


### PR DESCRIPTION
`wheels-macos` contains two folders, which contain the wheels.